### PR TITLE
Add ability to set logger in GSS-TSIG constructor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bodgit/tsig
 require (
 	github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5
 	github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815
+	github.com/go-logr/logr v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/jinzhu/copier v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815 h1:D22EM5TeYZJp43hGDx6dUng8mvtyYbB9BnE3+BmJR1Q=
 github.com/enceve/crypto v0.0.0-20160707101852-34d48bb93815/go.mod h1:wYFFK4LYXbX7j+76mOq7aiC/EAw2S22CrzPHqgsisPw=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=

--- a/gss/apcera.go
+++ b/gss/apcera.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bodgit/tsig"
 	"github.com/bodgit/tsig/internal/util"
+	"github.com/go-logr/logr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/miekg/dns"
 	"github.com/openshift/gssapi"
@@ -23,6 +24,7 @@ type Client struct {
 	lib    *gssapi.Lib
 	client *dns.Client
 	ctx    map[string]*gssapi.CtxId
+	logger logr.Logger
 }
 
 // WithConfig sets the Kerberos configuration used
@@ -53,6 +55,7 @@ func NewClient(dnsClient *dns.Client, options ...func(*Client) error) (*Client, 
 		lib:    lib,
 		client: client,
 		ctx:    make(map[string]*gssapi.CtxId),
+		logger: logr.Discard(),
 	}
 
 	if err := c.setOption(options...); err != nil {

--- a/gss/gokrb5.go
+++ b/gss/gokrb5.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/bodgit/tsig"
 	"github.com/bodgit/tsig/internal/util"
+	"github.com/go-logr/logr"
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/credentials"
@@ -117,6 +118,7 @@ type Client struct {
 	client *dns.Client
 	config string
 	ctx    map[string]context
+	logger logr.Logger
 }
 
 // WithConfig sets the Kerberos configuration used
@@ -142,6 +144,7 @@ func NewClient(dnsClient *dns.Client, options ...func(*Client) error) (*Client, 
 	c := &Client{
 		client: client,
 		ctx:    make(map[string]context),
+		logger: logr.Discard(),
 	}
 
 	if err := c.setOption(options...); err != nil {

--- a/gss/gss.go
+++ b/gss/gss.go
@@ -78,6 +78,7 @@ import (
 	"time"
 
 	"github.com/bodgit/tsig"
+	"github.com/go-logr/logr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/miekg/dns"
 )
@@ -154,4 +155,17 @@ func (c *Client) setOption(options ...func(*Client) error) error {
 // SetConfig sets the Kerberos configuration used by c
 func (c *Client) SetConfig(config string) error {
 	return c.setOption(WithConfig(config))
+}
+
+// WithLogger sets the logger used
+func WithLogger(logger logr.Logger) func(*Client) error {
+	return func(c *Client) error {
+		c.logger = logger
+		return nil
+	}
+}
+
+// SetLogger sets the logger used by c
+func (c *Client) SetLogger(logger logr.Logger) error {
+	return c.setOption(WithLogger(logger))
 }

--- a/gss/gss_test.go
+++ b/gss/gss_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bodgit/tsig"
+	"github.com/go-logr/logr"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 )
@@ -173,4 +174,9 @@ func testExchangeKeytab(t *testing.T) error {
 
 func TestExchange(t *testing.T) {
 	assert.Nil(t, testExchange(t))
+}
+
+func TestNewClientWithLogger(t *testing.T) {
+	_, err := NewClient(new(dns.Client), WithLogger(logr.Discard()))
+	assert.Nil(t, err)
 }

--- a/gss/sspi.go
+++ b/gss/sspi.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alexbrainman/sspi/negotiate"
 	"github.com/bodgit/tsig"
 	"github.com/bodgit/tsig/internal/util"
+	"github.com/go-logr/logr"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/miekg/dns"
 )
@@ -23,6 +24,7 @@ type Client struct {
 	m      sync.RWMutex
 	client *dns.Client
 	ctx    map[string]*negotiate.ClientContext
+	logger logr.Logger
 }
 
 // WithConfig sets the Kerberos configuration used
@@ -47,6 +49,7 @@ func NewClient(dnsClient *dns.Client, options ...func(*Client) error) (*Client, 
 	c := &Client{
 		client: client,
 		ctx:    make(map[string]*negotiate.ClientContext),
+		logger: logr.Discard(),
 	}
 
 	if err := c.setOption(options...); err != nil {


### PR DESCRIPTION
Chose logr as it's slightly more advanced than the stdlib log package.
Not currently utilised in the code but can now be sprinkled throughout
the code to help debugging. Default logger discards anything.