### PR TITLE
negotiateContext: Use current key as fallback if Subkey is not sent

### DIFF
--- a/gss/gokrb5.go
+++ b/gss/gokrb5.go
@@ -302,6 +302,7 @@ func (c *Client) negotiateContext(host string, cl *client.Client) (string, time.
 	}
 
 	var payload messages.EncAPRepPart
+	payload.Subkey = key // Use current key as fallback if Subkey is not sent
 	if err = payload.Unmarshal(b); err != nil {
 		return "", time.Time{}, err
 	}


### PR DESCRIPTION
I tried to use bodgit/tsig (or rather [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns/), which uses [miekg/dns](https://github.com/miekg/dns/), which uses bodgit/tsig) to perform dynamic DNS updates on a Samba Domain Controller (with a bind DNS backend). 

This failed with "`unknown or unsupported EType: 0`", because the `EncAPRepPart` of the TKEY reply does not contain a `Subkey`. 

According to https://www.rfc-editor.org/rfc/rfc4120#section-5.5.2 `subkey` is an optional field. If it is not sent, the session key from the ticket should be used.

With this change, updating DNS records in samba works.
